### PR TITLE
Split the codebase up into packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 main
 coverage.out
+gollum-page-watcher-action

--- a/github/github.go
+++ b/github/github.go
@@ -1,0 +1,22 @@
+package github
+
+// Page defines the struct of each page that has changed during the action. For more detail see https://developer.github.com/v3/activity/events/types/#gollumevent
+type Page struct {
+	Name   string `json:"page_name"`
+	Title  string `json:"title"`
+	Action string `json:"action"`
+	Sha    string `json:"sha"`
+	URL    string `json:"html_url"`
+}
+
+// Sender represents the author of the commit
+type Sender struct {
+	Login     string `json:"login"`
+	AvatarURL string `json:"avatar_url"`
+}
+
+// GollumEvent houses all of the Page structs. For more detail see https://developer.github.com/v3/activity/events/types/#gollumevent
+type GollumEvent struct {
+	Pages  []Page `json:"pages"`
+	Sender Sender `json:"sender"`
+}

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
 github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gorilla/websocket v1.2.0 h1:VJtLvh6VQym50czpZzx07z/kw9EgAxI3x1ZB8taTMQQ=
 github.com/gorilla/websocket v1.2.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
@@ -8,7 +10,9 @@ github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/slack-go/slack v0.6.2 h1:MAnjpRC+m082cFXT/BOYZOrlrZXJZIORfLqw9IwK/hI=
 github.com/slack-go/slack v0.6.2/go.mod h1:ZUNi+O1Pwr2ch2UOp2AfF+s7QYQgwht2Cd1UTeIYw9A=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -1,0 +1,18 @@
+package notifier
+
+import "github.com/benmatselby/gollum-page-watcher-action/github"
+
+// NotificationStrategy defines the interface for all notifiers
+type NotificationStrategy interface {
+	Send(event *github.GollumEvent) error
+}
+
+// Notifier allows for a strategy to be executed
+type Notifier struct {
+	Strategy NotificationStrategy
+}
+
+// Send communicates the event via the NotificationStrategy
+func (n *Notifier) Send(event *github.GollumEvent) error {
+	return n.Strategy.Send(event)
+}

--- a/notifier/slack.go
+++ b/notifier/slack.go
@@ -1,0 +1,47 @@
+package notifier
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/benmatselby/gollum-page-watcher-action/github"
+	"github.com/slack-go/slack"
+)
+
+// Slack implements the notifier strategy
+type Slack struct{}
+
+// Send communicates a message to the Slack API
+func (s *Slack) Send(event *github.GollumEvent) error {
+	content := ""
+	for _, page := range event.Pages {
+		content += fmt.Sprintf("<%s|%s>\n", page.URL, page.Title)
+	}
+
+	attachments := []slack.Attachment{slack.Attachment{
+		Color:      "#2e5685",
+		Text:       content,
+		AuthorName: event.Sender.Login,
+		AuthorIcon: event.Sender.AvatarURL,
+	}}
+
+	msg := &slack.WebhookMessage{
+		Text:        "The following pages have changed in the wiki",
+		Attachments: attachments,
+	}
+
+	if os.Getenv("SLACK_USERNAME") != "" {
+		msg.Username = os.Getenv("SLACK_USERNAME")
+	}
+
+	if os.Getenv("SLACK_CHANNEL") != "" {
+		msg.Channel = os.Getenv("SLACK_CHANNEL")
+	}
+
+	if os.Getenv("DEBUG") != "" {
+		fmt.Println(msg)
+		return nil
+	}
+
+	return slack.PostWebhook(os.Getenv("SLACK_WEBHOOK"), msg)
+}


### PR DESCRIPTION
This allows us to have many notifiers moving forward (should we wish)