### PR TITLE
Changed format of the Slack message to better match other apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To test this, you can run it from your command line with the following setup
 ```shell
 GITHUB_EVENT_PATH=example-payloads/valid-payload.json \
 GITHUB_EVENT_NAME=gollum \
-SLACK_WEBHOOK=[your-slack-webook-url] \
+SLACK_WEBHOOK=[your-slack-webhook-url] \
 SLACK_CHANNEL=[your-slack-channel] \
 DEBUG=true \
 go run main.go

--- a/notifier/slack.go
+++ b/notifier/slack.go
@@ -14,9 +14,9 @@ type Slack struct{}
 
 // Send communicates a message to the Slack API
 func (s *Slack) Send(config config.Config, event *github.GollumEvent) error {
-	content := ""
+	content := "The following pages have changed in the wiki:\n"
 	for _, page := range event.Pages {
-		content += fmt.Sprintf("<%s|%s>\n", page.URL, page.Title)
+		content += fmt.Sprintf("\t- <%s|%s>\n", page.URL, page.Title)
 	}
 
 	attachments := []slack.Attachment{{
@@ -24,11 +24,10 @@ func (s *Slack) Send(config config.Config, event *github.GollumEvent) error {
 		Text:       content,
 		AuthorName: event.Sender.Login,
 		AuthorIcon: event.Sender.AvatarURL,
+		Footer: fmt.Sprintf("<%s|%s>", event.Repo.URL, event.Repo.FullName),
 	}}
 
-	text := fmt.Sprintf("The following pages have changed in the <%s|%s> wiki\n", event.Repo.URL, event.Repo.FullName)
 	msg := &slack.WebhookMessage{
-		Text:        text,
 		Attachments: attachments,
 	}
 


### PR DESCRIPTION
Resolves #18 

It might need a bit of tweaking but I think it looks better being similar to the GitHub app but feel free to play around!

Example:

![image](https://user-images.githubusercontent.com/16718355/76239262-2a3c5680-6229-11ea-9b14-3a7bead61c5c.png)
