### PR TITLE
Bump Go to 1.17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.16.x]
+        go-version: [1.17.x]
     runs-on: ubuntu-latest
     name: Build
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## next
 
+- Bumped docker image to Go 1.17 runtime.
+
 ## 1.5.0
 
 - Bumped docker image to Go 1.16 runtime.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## next
+## 1.6.0
 
 - Bumped docker image to Go 1.17 runtime.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.7-alpine
+FROM golang:1.17.1-alpine
 LABEL maintainer="Ben Selby <benmatselby@gmail.com>"
 
 RUN apk add --no-cache \

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module github.com/benmatselby/gollum-page-watcher-action
 
-go 1.16
+go 1.17
 
 require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/slack-go/slack v0.9.4
 )
+
+require github.com/gorilla/websocket v1.4.2 // indirect


### PR DESCRIPTION
- Bump the go version to 1.17
- Prepare for the 1.6.0 release
