### PR TITLE
Bump Go runtime to 1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.8.0
+
+- Bumped docker image to Go 1.20 runtime.
+- Moved the default branch to `main`, and left `master` running the v1.7.0 version.
+
 ## 1.7.0
 
 - Bumped docker image to Go 1.18 runtime.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.5-alpine
+FROM golang:1.20.3-alpine
 LABEL maintainer="Ben Selby <benmatselby@gmail.com>"
 
 RUN apk add --no-cache \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/benmatselby/gollum-page-watcher-action
 
-go 1.18
+go 1.20
 
 require github.com/slack-go/slack v0.12.1
 


### PR DESCRIPTION
- Bump to Go 1.20
- Get ready for the 1.8.0 release
